### PR TITLE
Fixed small bug which causes non-square input textures to produce a faulty SDF texture

### DIFF
--- a/Assets/SignedDistanceFields/SignedDistanceFieldGenerator.cs
+++ b/Assets/SignedDistanceFields/SignedDistanceFieldGenerator.cs
@@ -414,7 +414,7 @@ public class SignedDistanceFieldGenerator
     {
         for (int y = 0; y < m_y_dims; y++)
         {
-            for (int x = 0; x < m_y_dims; x++)
+            for (int x = 0; x < m_x_dims; x++)
             {
                 Pixel pix = GetPixel(x, y);
                 pix.edge = IsEdgePixel(x, y); //for eikonal sweep, mark edge pixels


### PR DESCRIPTION
Fixed small bug which causes non-square input textures to produce a faulty SDF texture.

Superb Blog series on SDF btw. I read all of it and enjoyed it very much. Thank you!